### PR TITLE
Use correct mechanism to disable auto-sizes CSS fix

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1512,6 +1512,6 @@ function utopia_utopians_archive_page( $query ) {
 	}
 }
 
-remove_action( 'wp_head', 'wp_print_auto_sizes_contain_css_fix', 1 );
+add_filter( 'wp_img_tag_add_auto_sizes', '__return_false' );
 
 require_once get_template_directory() . '/inc/translations.php';


### PR DESCRIPTION
As per https://core.trac.wordpress.org/ticket/62731 we may be using a different function that hooks into `wp_enqueue_scripts` instead of `wp_head`. There is also a `wp_img_tag_add_auto_sizes` filter specifically for the purpose of disabling this style, so it should be used instead.